### PR TITLE
NWA-1268: Extended HTTP codes for zones and upstreams.

### DIFF
--- a/src/__test__/utils.test.js
+++ b/src/__test__/utils.test.js
@@ -10,7 +10,8 @@ import {
 	formatUptime,
 	formatReadableBytes,
 	formatMs,
-	formatDate
+	formatDate,
+	getHTTPCodesArray,
 } from '../utils.js';
 
 describe('Utils', () => {
@@ -94,5 +95,39 @@ describe('Utils', () => {
 			`${ hours < 10 ? '0' : '' }${ hours }:${ minutes < 10 ? '0' : '' }${ minutes }:${ seconds < 10 ? '0' : '' }${ seconds }`,
 			tz
 		].join(' '));
+	});
+
+	it('getHTTPCodesArray()', () => {
+		[{
+			testCase: "No codes",
+			args: [null, '2'],
+			result: [],
+		}, {
+			testCase: "Empty codes",
+			args: [{}, '2'],
+			result: [],
+		}, {
+			testCase: "Non empty codes",
+			args: [{
+				'200': 1000,
+				'201': 3,
+				'301': 1,
+				'404': 5,
+				'500': 25,
+				'202': 4,
+			}, '2'],
+			result: [{
+				code: '200',
+				value: 1000,
+			}, {
+				code: '201',
+				value: 3,
+			}, {
+				code: '202',
+				value: 4,
+			}],
+		}].forEach(({ testCase, args, result }) => {
+			expect(getHTTPCodesArray(...args), testCase).to.deep.equal(result)
+		});
 	});
 });

--- a/src/api/__test__/index.test.js
+++ b/src/api/__test__/index.test.js
@@ -9,6 +9,8 @@
 /* eslint-env browser, mocha */
 /* eslint no-underscore-dangle: "off" */
 
+import { spy, stub } from 'sinon';
+
 import datastore from '../../datastore';
 import api, * as Api from '../index.js';
 import ApiProxy from '../ApiProxy.js';
@@ -25,7 +27,6 @@ import calculateSSL from '../../calculators/ssl.js';
 import calculateRequests from '../../calculators/requests.js';
 import calculateZoneSync from '../../calculators/zonesync.js';
 import calculateResolvers from '../../calculators/resolvers.js';
-import { spy, stub } from 'sinon';
 
 describe('Api', () => {
 	it('Returns new instance of ApiProxy', () => {
@@ -69,7 +70,7 @@ describe('Api', () => {
 			Api.checkWritePermissions();
 
 			assert(
-				window.fetch.args[0][0] === '/api/6/http/upstreams/DASHBOARD_INIT/servers/__TEST_FOR_WRITE__/',
+				window.fetch.args[0][0] === `${ API_PATH }/http/upstreams/DASHBOARD_INIT/servers/__TEST_FOR_WRITE__/`,
 				'Unexpected path was passed to "window.fetch"'
 			);
 
@@ -163,7 +164,7 @@ describe('Api', () => {
 
 			Api.checkApiAvailability();
 
-			assert(window.fetch.args[0][0] === '/api/6/nginx/', 'Unexpected path was passed to "window.fetch"');
+			assert(window.fetch.args[0][0] === `${ API_PATH }/nginx/`, 'Unexpected path was passed to "window.fetch"');
 
 			window.fetch = _fetchInner;
 		});

--- a/src/components/pages/caches/index.jsx
+++ b/src/components/pages/caches/index.jsx
@@ -6,17 +6,17 @@
  */
 
 import React from 'react';
-import api from '../../../api';
+
+import api from '#/api';
 import DataBinder from '../../databinder/databinder.jsx';
 import ProgressBar from '../../progressbar/progressbar.jsx';
 import GaugeIndicator from '../../gaugeindicator/gaugeindicator.jsx';
 import Icon from '../../icon/icon.jsx';
-import cacheCalculator from '../../../calculators/caches.js';
-import sharedZonesCalculator from '../../../calculators/sharedzones.js';
-import utils from '../../../utils.js';
-import tooltips from '../../../tooltips/index.jsx';
+import cacheCalculator from '#/calculators/caches.js';
+import sharedZonesCalculator from '#/calculators/sharedzones.js';
+import utils from '#/utils.js';
+import tooltips from '#/tooltips/index.jsx';
 import { CacheStateTooltip, SharedZoneTooltip } from '../tooltips.jsx';
-
 import styles from '../../table/style.css';
 import cachesStyles from './style.css';
 

--- a/src/components/pages/index/aboutnginx/aboutnginx.jsx
+++ b/src/components/pages/index/aboutnginx/aboutnginx.jsx
@@ -6,12 +6,12 @@
  */
 
 import React from 'react';
+
 import IndexBox from '../indexbox/indexbox.jsx';
 import DataBinder from '../../../databinder/databinder.jsx';
-import api from '../../../../api';
-import utils from '../../../../utils.js';
-import tooltips from '../../../../tooltips/index.jsx';
-
+import api from '#/api';
+import utils from '#/utils.js';
+import tooltips from '#/tooltips/index.jsx';
 import styles from './style.css';
 import tooltipStyles from '../../../tooltip/style.css';
 

--- a/src/components/pages/index/serverzones/serverzones.jsx
+++ b/src/components/pages/index/serverzones/serverzones.jsx
@@ -7,13 +7,14 @@
  */
 
 import React from 'react';
+
 import IndexBox from '../indexbox/indexbox.jsx';
 import AlertsCount from '../alertscount/alertscount.jsx';
 import DataBinder from '../../../databinder/databinder.jsx';
-import api from '../../../../api';
-import calculateServerZones from '../../../../calculators/serverzones.js';
-import calculateLocationZones from '../../../../calculators/locationzones.js';
-import utils from '../../../../utils.js';
+import api from '#/api';
+import calculateServerZones from '#/calculators/serverzones.js';
+import calculateLocationZones from '#/calculators/locationzones.js';
+import utils from '#/utils.js';
 
 export class ServerZones extends React.Component {
 	render() {

--- a/src/components/pages/index/streamzones/streamzones.jsx
+++ b/src/components/pages/index/streamzones/streamzones.jsx
@@ -6,11 +6,12 @@
  */
 
 import React from 'react';
+
 import IndexBox from '../indexbox/indexbox.jsx';
 import DataBinder from '../../../databinder/databinder.jsx';
-import api from '../../../../api';
-import utils from '../../../../utils.js';
-import { zones } from '../../../../calculators/stream.js';
+import api from '#/api';
+import utils from '#/utils.js';
+import { zones } from '#/calculators/stream.js';
 
 export class StreamZones extends React.Component {
 	render() {

--- a/src/components/pages/serverzones/__test__/locationzones.test.jsx
+++ b/src/components/pages/serverzones/__test__/locationzones.test.jsx
@@ -8,11 +8,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { spy, stub } from 'sinon';
+
 import Locations from '../locationzones.jsx';
-import SortableTable from '../../../table/sortabletable.jsx';
-import styles from '../../../table/style.css';
-import utils from '../../../../utils';
-import tooltips from '../../../../tooltips/index.jsx';
+import { SortableTable, tableUtils, styles } from '#/components/table';
+import utils from '#/utils';
+import tooltips from '#/tooltips/index.jsx';
 
 describe('<Locations />', () => {
 	it('extends SortableTable', () => {
@@ -116,68 +116,82 @@ describe('<Locations />', () => {
 			stub(utils, 'formatReadableBytes').callsFake(
 				a => `formatted_${ a }`
 			);
+			spy(utils, 'getHTTPCodesArray');
+			stub(tableUtils, 'responsesTextWithTooltip').callsFake(value => value);
+
+			const items = [
+				['test', {
+					warning: false,
+					'5xxChanged': false,
+					requests: 100,
+					zone_req_s: 10,
+					responses: {
+						'1xx': 0,
+						'2xx': 500,
+						'3xx': 1,
+						'4xx': 5,
+						'5xx': 0,
+						codes: {
+							'404': 1,
+							'403': 2,
+						},
+						total: 506
+					},
+					'4xxChanged': false,
+					discarded: 2,
+					sent_s: 1,
+					rcvd_s: 2,
+					sent: 3,
+					received: 4
+				}], ['test_2', {
+					warning: true,
+					'5xxChanged': false,
+					requests: 1000,
+					zone_req_s: 100,
+					responses: {
+						'1xx': 1,
+						'2xx': 5000,
+						'3xx': 10,
+						'4xx': 50,
+						'5xx': 1,
+						codes: {
+							'100': 1,
+						},
+						total: 5062
+					},
+					'4xxChanged': true,
+					discarded: 3,
+					sent_s: 2,
+					rcvd_s: 3,
+					sent: 4,
+					received: 5
+				}], ['test_3', {
+					warning: false,
+					'5xxChanged': true,
+					requests: 10,
+					zone_req_s: 1,
+					responses: {
+						'1xx': 0,
+						'2xx': 2,
+						'3xx': 0,
+						'4xx': 0,
+						'5xx': 0,
+						codes: {
+							'200': 2,
+						},
+						total: 2
+					},
+					'4xxChanged': false,
+					discarded: 4,
+					sent_s: 3,
+					rcvd_s: 4,
+					sent: 5,
+					received: 6
+				}]
+			];
 
 			const wrapper = shallow(
-				<Locations data={ new Map([
-					['test', {
-						warning: false,
-						'5xxChanged': false,
-						requests: 100,
-						zone_req_s: 10,
-						responses: {
-							'1xx': 0,
-							'2xx': 500,
-							'3xx': 1,
-							'4xx': 5,
-							'5xx': 0,
-							total: 506
-						},
-						'4xxChanged': false,
-						discarded: 2,
-						sent_s: 1,
-						rcvd_s: 2,
-						sent: 3,
-						received: 4
-					}], ['test_2', {
-						warning: true,
-						'5xxChanged': false,
-						requests: 1000,
-						zone_req_s: 100,
-						responses: {
-							'1xx': 1,
-							'2xx': 5000,
-							'3xx': 10,
-							'4xx': 50,
-							'5xx': 1,
-							total: 5062
-						},
-						'4xxChanged': true,
-						discarded: 3,
-						sent_s: 2,
-						rcvd_s: 3,
-						sent: 4,
-						received: 5
-					}], ['test_3', {
-						warning: false,
-						'5xxChanged': true,
-						requests: 10,
-						zone_req_s: 1,
-						responses: {
-							'1xx': 0,
-							'2xx': 2,
-							'3xx': 0,
-							'4xx': 0,
-							'5xx': 0,
-							total: 2
-						},
-						'4xxChanged': false,
-						discarded: 4,
-						sent_s: 3,
-						rcvd_s: 4,
-						sent: 5,
-						received: 6
-					}]
-				]) } />
+				<Locations data={ new Map(items) } />
 			);
 			const rows = wrapper.find('tbody tr');
 			let cells, cell;
@@ -361,58 +375,125 @@ describe('<Locations />', () => {
 			);
 			expect(cell.text(), 'row 3, cell 14, text').to.be.equal('formatted_6');
 
-			expect(tooltips.useTooltip.calledThrice, 'useTooltip called').to.be.true;
+			expect(tableUtils.responsesTextWithTooltip.callCount, 'responsesTextWithTooltip called 12 times').to.be.equal(12);
+			expect(tableUtils.responsesTextWithTooltip.args[0][0], 'responsesTextWithTooltip row 1, arg 1, 1xx').to.be.equal(items[0][1].responses['1xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[0][1], 'responsesTextWithTooltip row 1, arg 2, 1xx').to.be.equal(items[0][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[0][2], 'responsesTextWithTooltip row 1, arg 3, 1xx').to.be.equal('1');
+			expect(tableUtils.responsesTextWithTooltip.args[1][0], 'responsesTextWithTooltip row 1, arg 1, 2xx').to.be.equal(items[0][1].responses['2xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[1][1], 'responsesTextWithTooltip row 1, arg 2, 2xx').to.be.equal(items[0][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[1][2], 'responsesTextWithTooltip row 1, arg 3, 2xx').to.be.equal('2');
+			expect(tableUtils.responsesTextWithTooltip.args[2][0], 'responsesTextWithTooltip row 1, arg 1, 3xx').to.be.equal(items[0][1].responses['3xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[2][1], 'responsesTextWithTooltip row 1, arg 2, 3xx').to.be.equal(items[0][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[2][2], 'responsesTextWithTooltip row 1, arg 3, 3xx').to.be.equal('3');
+			expect(tableUtils.responsesTextWithTooltip.args[3][0], 'responsesTextWithTooltip row 1, arg 1, 5xx').to.be.equal(items[0][1].responses['5xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[3][1], 'responsesTextWithTooltip row 1, arg 2, 5xx').to.be.equal(items[0][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[3][2], 'responsesTextWithTooltip row 1, arg 3, 5xx').to.be.equal('5');
+			expect(tableUtils.responsesTextWithTooltip.args[4][0], 'responsesTextWithTooltip row 2, arg 1, 1xx').to.be.equal(items[1][1].responses['1xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[4][1], 'responsesTextWithTooltip row 2, arg 2, 1xx').to.be.equal(items[1][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[4][2], 'responsesTextWithTooltip row 2, arg 3, 1xx').to.be.equal('1');
+			expect(tableUtils.responsesTextWithTooltip.args[5][0], 'responsesTextWithTooltip row 2, arg 1, 2xx').to.be.equal(items[1][1].responses['2xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[5][1], 'responsesTextWithTooltip row 2, arg 2, 2xx').to.be.equal(items[1][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[5][2], 'responsesTextWithTooltip row 2, arg 3, 2xx').to.be.equal('2');
+			expect(tableUtils.responsesTextWithTooltip.args[6][0], 'responsesTextWithTooltip row 2, arg 1, 3xx').to.be.equal(items[1][1].responses['3xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[6][1], 'responsesTextWithTooltip row 2, arg 2, 3xx').to.be.equal(items[1][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[6][2], 'responsesTextWithTooltip row 2, arg 3, 3xx').to.be.equal('3');
+			expect(tableUtils.responsesTextWithTooltip.args[7][0], 'responsesTextWithTooltip row 2, arg 1, 5xx').to.be.equal(items[1][1].responses['5xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[7][1], 'responsesTextWithTooltip row 2, arg 2, 5xx').to.be.equal(items[1][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[7][2], 'responsesTextWithTooltip row 2, arg 3, 5xx').to.be.equal('5');
+			expect(tableUtils.responsesTextWithTooltip.args[8][0], 'responsesTextWithTooltip row 3, arg 1, 1xx').to.be.equal(items[2][1].responses['1xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[8][1], 'responsesTextWithTooltip row 3, arg 2, 1xx').to.be.equal(items[2][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[8][2], 'responsesTextWithTooltip row 3, arg 3, 1xx').to.be.equal('1');
+			expect(tableUtils.responsesTextWithTooltip.args[9][0], 'responsesTextWithTooltip row 3, arg 1, 2xx').to.be.equal(items[2][1].responses['2xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[9][1], 'responsesTextWithTooltip row 3, arg 2, 2xx').to.be.equal(items[2][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[9][2], 'responsesTextWithTooltip row 3, arg 3, 2xx').to.be.equal('2');
+			expect(tableUtils.responsesTextWithTooltip.args[10][0], 'responsesTextWithTooltip row 3, arg 1, 3xx').to.be.equal(items[2][1].responses['3xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[10][1], 'responsesTextWithTooltip row 3, arg 2, 3xx').to.be.equal(items[2][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[10][2], 'responsesTextWithTooltip row 3, arg 3, 3xx').to.be.equal('3');
+			expect(tableUtils.responsesTextWithTooltip.args[11][0], 'responsesTextWithTooltip row 3, arg 1, 5xx').to.be.equal(items[2][1].responses['5xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[11][1], 'responsesTextWithTooltip row 3, arg 2, 5xx').to.be.equal(items[2][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[11][2], 'responsesTextWithTooltip row 3, arg 3, 5xx').to.be.equal('5');
+
+			expect(utils.getHTTPCodesArray.calledThrice, 'getHTTPCodesArray called thrice').to.be.true;
+			expect(utils.getHTTPCodesArray.args[0][0], 'getHTTPCodesArray call 1, arg 1').to.be.equal(items[0][1].responses.codes);
+			expect(utils.getHTTPCodesArray.args[0][1], 'getHTTPCodesArray call 1, arg 2').to.be.equal('4');
+			expect(utils.getHTTPCodesArray.args[1][0], 'getHTTPCodesArray call 2, arg 1').to.be.equal(items[1][1].responses.codes);
+			expect(utils.getHTTPCodesArray.args[1][1], 'getHTTPCodesArray call 2, arg 2').to.be.equal('4');
+			expect(utils.getHTTPCodesArray.args[2][0], 'getHTTPCodesArray call 3, arg 1').to.be.equal(items[2][1].responses.codes);
+			expect(utils.getHTTPCodesArray.args[2][1], 'getHTTPCodesArray call 3, arg 2').to.be.equal('4');
+
+			expect(tooltips.useTooltip.calledThrice, 'useTooltip called thrice').to.be.true;
+			const codeRows = tooltips.useTooltip.args[0][0].props.children[0];
 			expect(
-				tooltips.useTooltip.args[0][0].props.children[0],
-				'useTooltip call 1'
-			).to.contain('4xx:');
+				codeRows,
+				'useTooltip row 1, response code rows length'
+			).to.have.lengthOf(2);
 			expect(
-				tooltips.useTooltip.args[0][0].props.children[1],
-				'useTooltip call 1'
-			).to.be.equal(5);
+				codeRows[0].props.children[0],
+				'useTooltip row 1, response code row 1, key'
+			).to.be.equal('403');
 			expect(
-				tooltips.useTooltip.args[0][0].props.children[4],
-				'useTooltip call 1'
-			).to.contain('499/444/408:');
+				codeRows[0].props.children[2],
+				'useTooltip row 1, response code row 1, value'
+			).to.be.equal(items[0][1].responses.codes['403']);
 			expect(
-				tooltips.useTooltip.args[0][0].props.children[5],
-				'useTooltip call 1'
-			).to.be.equal(2);
-			expect(tooltips.useTooltip.args[0][1], 'useTooltip call 1').to.be.equal('hint');
+				codeRows[1].props.children[0],
+				'useTooltip row 1, response code row 2, key'
+			).to.be.equal('404');
 			expect(
-				tooltips.useTooltip.args[1][0].props.children[0],
-				'useTooltip call 2'
-			).to.contain('4xx:');
+				codeRows[1].props.children[2],
+				'useTooltip row 1, response code row 2, value'
+			).to.be.equal(items[0][1].responses.codes['404']);
 			expect(
-				tooltips.useTooltip.args[1][0].props.children[1],
-				'useTooltip call 2'
-			).to.be.equal(50);
+				tooltips.useTooltip.args[0][0].props.children[1].props.children[0],
+				'useTooltip row 1, 499/444/408 row'
+			).to.contain('499/444/408');
 			expect(
-				tooltips.useTooltip.args[1][0].props.children[4],
-				'useTooltip call 2'
-			).to.contain('499/444/408:');
+				tooltips.useTooltip.args[0][0].props.children[1].props.children[1],
+				'useTooltip row 1, 499/444/408 row'
+			).to.be.equal(items[0][1].discarded);
+			expect(tooltips.useTooltip.args[0][1], 'useTooltip row 1, mode').to.be.equal('hint');
 			expect(
-				tooltips.useTooltip.args[1][0].props.children[5],
-				'useTooltip call 2'
-			).to.be.equal(3);
-			expect(tooltips.useTooltip.args[1][1], 'useTooltip call 2').to.be.equal('hint');
+				tooltips.useTooltip.args[1][0].props.children,
+				'useTooltip row 2, content length'
+			).to.have.lengthOf(2);
 			expect(
-				tooltips.useTooltip.args[2][0].props.children[0],
-				'useTooltip call 3'
-			).to.contain('4xx:');
+				tooltips.useTooltip.args[1][0].props.children[0].props.children[0],
+				'useTooltip row 2, 4xx row'
+			).to.contain('4xx');
 			expect(
-				tooltips.useTooltip.args[2][0].props.children[1],
-				'useTooltip call 3'
-			).to.be.equal(0);
+				tooltips.useTooltip.args[1][0].props.children[0].props.children[1],
+				'useTooltip row 2, 4xx row'
+			).to.be.equal(items[1][1].responses['4xx']);
 			expect(
-				tooltips.useTooltip.args[2][0].props.children[4],
-				'useTooltip call 3'
-			).to.contain('499/444/408:');
+				tooltips.useTooltip.args[1][0].props.children[1].props.children[0],
+				'useTooltip row 2, 499/444/408 row'
+			).to.contain('499/444/408');
 			expect(
-				tooltips.useTooltip.args[2][0].props.children[5],
-				'useTooltip call 3'
-			).to.be.equal(4);
-			expect(tooltips.useTooltip.args[2][1], 'useTooltip call 3').to.be.equal('hint');
+				tooltips.useTooltip.args[1][0].props.children[1].props.children[1],
+				'useTooltip row 2, 499/444/408 row'
+			).to.be.equal(items[1][1].discarded);
+			expect(tooltips.useTooltip.args[1][1], 'useTooltip row 2, mode').to.be.equal('hint');
+			expect(
+				tooltips.useTooltip.args[2][0].props.children,
+				'useTooltip row 3, content length'
+			).to.have.lengthOf(2);
+			expect(
+				tooltips.useTooltip.args[2][0].props.children[0].props.children[0],
+				'useTooltip row 3, 4xx row'
+			).to.contain('4xx');
+			expect(
+				tooltips.useTooltip.args[2][0].props.children[0].props.children[1],
+				'useTooltip row 3, 4xx row'
+			).to.be.equal(items[2][1].responses['4xx']);
+			expect(
+				tooltips.useTooltip.args[2][0].props.children[1].props.children[0],
+				'useTooltip row 3, 499/444/408 row'
+			).to.contain('499/444/408');
+			expect(
+				tooltips.useTooltip.args[2][0].props.children[1].props.children[1],
+				'useTooltip row 3, 499/444/408 row'
+			).to.be.equal(items[2][1].discarded);
+			expect(tooltips.useTooltip.args[2][1], 'useTooltip row 3, mode').to.be.equal('hint');
 
 			expect(utils.formatReadableBytes.callCount, 'useTooltip called').to.be.equal(12);
 			expect(utils.formatReadableBytes.args[0][0], 'useTooltip call 1 arg').to.be.equal(1);
@@ -430,6 +511,8 @@ describe('<Locations />', () => {
 
 			utils.formatReadableBytes.restore();
 			tooltips.useTooltip.restore();
+			utils.getHTTPCodesArray.restore();
+			tableUtils.responsesTextWithTooltip.restore();
 			wrapper.unmount();
 		});
 	});

--- a/src/components/pages/serverzones/__test__/serverzones.test.jsx
+++ b/src/components/pages/serverzones/__test__/serverzones.test.jsx
@@ -8,11 +8,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { spy, stub } from 'sinon';
+
 import ServerZones from '../serverzones.jsx';
-import SortableTable from '../../../table/sortabletable.jsx';
-import styles from '../../../table/style.css';
-import utils from '../../../../utils';
-import tooltips from '../../../../tooltips/index.jsx';
+import { SortableTable, tableUtils, styles } from '#/components/table';
+import utils from '#/utils';
+import tooltips from '#/tooltips/index.jsx';
 
 describe('<ServerZones />', () => {
 	it('extends SortableTable', () => {
@@ -116,71 +116,84 @@ describe('<ServerZones />', () => {
 			stub(utils, 'formatReadableBytes').callsFake(
 				a => `formatted_${ a }`
 			);
+			spy(utils, 'getHTTPCodesArray');
+			stub(tableUtils, 'responsesTextWithTooltip').callsFake(value => value);
 
+			const items = [
+				['test', {
+					warning: false,
+					'5xxChanged': false,
+					processing: 99,
+					requests: 100,
+					zone_req_s: 10,
+					responses: {
+						'1xx': 0,
+						'2xx': 500,
+						'3xx': 1,
+						'4xx': 5,
+						'5xx': 0,
+						codes: {
+							'404': 1,
+							'403': 2,
+						},
+						total: 506
+					},
+					'4xxChanged': false,
+					discarded: 2,
+					sent_s: 1,
+					rcvd_s: 2,
+					sent: 3,
+					received: 4
+				}], ['test_2', {
+					warning: true,
+					'5xxChanged': false,
+					processing: 999,
+					requests: 1000,
+					zone_req_s: 100,
+					responses: {
+						'1xx': 1,
+						'2xx': 5000,
+						'3xx': 10,
+						'4xx': 50,
+						'5xx': 1,
+						codes: {
+							'100': 1,
+						},
+						total: 5062
+					},
+					'4xxChanged': true,
+					discarded: 3,
+					sent_s: 2,
+					rcvd_s: 3,
+					sent: 4,
+					received: 5
+				}], ['test_3', {
+					warning: false,
+					'5xxChanged': true,
+					processing: 9,
+					requests: 10,
+					zone_req_s: 1,
+					responses: {
+						'1xx': 0,
+						'2xx': 2,
+						'3xx': 0,
+						'4xx': 0,
+						'5xx': 0,
+						codes: {
+							'200': 2,
+						},
+						total: 2
+					},
+					'4xxChanged': false,
+					discarded: 4,
+					sent_s: 3,
+					rcvd_s: 4,
+					sent: 5,
+					received: 6
+				}]
+			];
 			const wrapper = shallow(
-				<ServerZones data={ new Map([
-					['test', {
-						warning: false,
-						'5xxChanged': false,
-						processing: 99,
-						requests: 100,
-						zone_req_s: 10,
-						responses: {
-							'1xx': 0,
-							'2xx': 500,
-							'3xx': 1,
-							'4xx': 5,
-							'5xx': 0,
-							total: 506
-						},
-						'4xxChanged': false,
-						discarded: 2,
-						sent_s: 1,
-						rcvd_s: 2,
-						sent: 3,
-						received: 4
-					}], ['test_2', {
-						warning: true,
-						'5xxChanged': false,
-						processing: 999,
-						requests: 1000,
-						zone_req_s: 100,
-						responses: {
-							'1xx': 1,
-							'2xx': 5000,
-							'3xx': 10,
-							'4xx': 50,
-							'5xx': 1,
-							total: 5062
-						},
-						'4xxChanged': true,
-						discarded: 3,
-						sent_s: 2,
-						rcvd_s: 3,
-						sent: 4,
-						received: 5
-					}], ['test_3', {
-						warning: false,
-						'5xxChanged': true,
-						processing: 9,
-						requests: 10,
-						zone_req_s: 1,
-						responses: {
-							'1xx': 0,
-							'2xx': 2,
-							'3xx': 0,
-							'4xx': 0,
-							'5xx': 0,
-							total: 2
-						},
-						'4xxChanged': false,
-						discarded: 4,
-						sent_s: 3,
-						rcvd_s: 4,
-						sent: 5,
-						received: 6
-					}]
-				]) } />
+				<ServerZones data={ new Map(items) } />
 			);
 			const rows = wrapper.find('tbody tr');
 			let cells, cell;
@@ -367,58 +380,125 @@ describe('<ServerZones />', () => {
 			);
 			expect(cell.text(), 'row 3, cell 15, text').to.be.equal('formatted_6');
 
-			expect(tooltips.useTooltip.calledThrice, 'useTooltip called').to.be.true;
+			expect(tableUtils.responsesTextWithTooltip.callCount, 'responsesTextWithTooltip called 12 times').to.be.equal(12);
+			expect(tableUtils.responsesTextWithTooltip.args[0][0], 'responsesTextWithTooltip row 1, arg 1, 1xx').to.be.equal(items[0][1].responses['1xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[0][1], 'responsesTextWithTooltip row 1, arg 2, 1xx').to.be.equal(items[0][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[0][2], 'responsesTextWithTooltip row 1, arg 3, 1xx').to.be.equal('1');
+			expect(tableUtils.responsesTextWithTooltip.args[1][0], 'responsesTextWithTooltip row 1, arg 1, 2xx').to.be.equal(items[0][1].responses['2xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[1][1], 'responsesTextWithTooltip row 1, arg 2, 2xx').to.be.equal(items[0][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[1][2], 'responsesTextWithTooltip row 1, arg 3, 2xx').to.be.equal('2');
+			expect(tableUtils.responsesTextWithTooltip.args[2][0], 'responsesTextWithTooltip row 1, arg 1, 3xx').to.be.equal(items[0][1].responses['3xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[2][1], 'responsesTextWithTooltip row 1, arg 2, 3xx').to.be.equal(items[0][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[2][2], 'responsesTextWithTooltip row 1, arg 3, 3xx').to.be.equal('3');
+			expect(tableUtils.responsesTextWithTooltip.args[3][0], 'responsesTextWithTooltip row 1, arg 1, 5xx').to.be.equal(items[0][1].responses['5xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[3][1], 'responsesTextWithTooltip row 1, arg 2, 5xx').to.be.equal(items[0][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[3][2], 'responsesTextWithTooltip row 1, arg 3, 5xx').to.be.equal('5');
+			expect(tableUtils.responsesTextWithTooltip.args[4][0], 'responsesTextWithTooltip row 2, arg 1, 1xx').to.be.equal(items[1][1].responses['1xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[4][1], 'responsesTextWithTooltip row 2, arg 2, 1xx').to.be.equal(items[1][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[4][2], 'responsesTextWithTooltip row 2, arg 3, 1xx').to.be.equal('1');
+			expect(tableUtils.responsesTextWithTooltip.args[5][0], 'responsesTextWithTooltip row 2, arg 1, 2xx').to.be.equal(items[1][1].responses['2xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[5][1], 'responsesTextWithTooltip row 2, arg 2, 2xx').to.be.equal(items[1][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[5][2], 'responsesTextWithTooltip row 2, arg 3, 2xx').to.be.equal('2');
+			expect(tableUtils.responsesTextWithTooltip.args[6][0], 'responsesTextWithTooltip row 2, arg 1, 3xx').to.be.equal(items[1][1].responses['3xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[6][1], 'responsesTextWithTooltip row 2, arg 2, 3xx').to.be.equal(items[1][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[6][2], 'responsesTextWithTooltip row 2, arg 3, 3xx').to.be.equal('3');
+			expect(tableUtils.responsesTextWithTooltip.args[7][0], 'responsesTextWithTooltip row 2, arg 1, 5xx').to.be.equal(items[1][1].responses['5xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[7][1], 'responsesTextWithTooltip row 2, arg 2, 5xx').to.be.equal(items[1][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[7][2], 'responsesTextWithTooltip row 2, arg 3, 5xx').to.be.equal('5');
+			expect(tableUtils.responsesTextWithTooltip.args[8][0], 'responsesTextWithTooltip row 3, arg 1, 1xx').to.be.equal(items[2][1].responses['1xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[8][1], 'responsesTextWithTooltip row 3, arg 2, 1xx').to.be.equal(items[2][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[8][2], 'responsesTextWithTooltip row 3, arg 3, 1xx').to.be.equal('1');
+			expect(tableUtils.responsesTextWithTooltip.args[9][0], 'responsesTextWithTooltip row 3, arg 1, 2xx').to.be.equal(items[2][1].responses['2xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[9][1], 'responsesTextWithTooltip row 3, arg 2, 2xx').to.be.equal(items[2][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[9][2], 'responsesTextWithTooltip row 3, arg 3, 2xx').to.be.equal('2');
+			expect(tableUtils.responsesTextWithTooltip.args[10][0], 'responsesTextWithTooltip row 3, arg 1, 3xx').to.be.equal(items[2][1].responses['3xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[10][1], 'responsesTextWithTooltip row 3, arg 2, 3xx').to.be.equal(items[2][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[10][2], 'responsesTextWithTooltip row 3, arg 3, 3xx').to.be.equal('3');
+			expect(tableUtils.responsesTextWithTooltip.args[11][0], 'responsesTextWithTooltip row 3, arg 1, 5xx').to.be.equal(items[2][1].responses['5xx']);
+			expect(tableUtils.responsesTextWithTooltip.args[11][1], 'responsesTextWithTooltip row 3, arg 2, 5xx').to.be.equal(items[2][1].responses.codes);
+			expect(tableUtils.responsesTextWithTooltip.args[11][2], 'responsesTextWithTooltip row 3, arg 3, 5xx').to.be.equal('5');
+
+			expect(utils.getHTTPCodesArray.calledThrice, 'getHTTPCodesArray called thrice').to.be.true;
+			expect(utils.getHTTPCodesArray.args[0][0], 'getHTTPCodesArray call 1, arg 1').to.be.equal(items[0][1].responses.codes);
+			expect(utils.getHTTPCodesArray.args[0][1], 'getHTTPCodesArray call 1, arg 2').to.be.equal('4');
+			expect(utils.getHTTPCodesArray.args[1][0], 'getHTTPCodesArray call 2, arg 1').to.be.equal(items[1][1].responses.codes);
+			expect(utils.getHTTPCodesArray.args[1][1], 'getHTTPCodesArray call 2, arg 2').to.be.equal('4');
+			expect(utils.getHTTPCodesArray.args[2][0], 'getHTTPCodesArray call 3, arg 1').to.be.equal(items[2][1].responses.codes);
+			expect(utils.getHTTPCodesArray.args[2][1], 'getHTTPCodesArray call 3, arg 2').to.be.equal('4');
+
+			expect(tooltips.useTooltip.calledThrice, 'useTooltip called thrice').to.be.true;
+			const codeRows = tooltips.useTooltip.args[0][0].props.children[0];
 			expect(
-				tooltips.useTooltip.args[0][0].props.children[0],
-				'useTooltip call 1'
-			).to.contain('4xx:');
+				codeRows,
+				'useTooltip row 1, response code rows length'
+			).to.have.lengthOf(2);
 			expect(
-				tooltips.useTooltip.args[0][0].props.children[1],
-				'useTooltip call 1'
-			).to.be.equal(5);
+				codeRows[0].props.children[0],
+				'useTooltip row 1, response code row 1, key'
+			).to.be.equal('403');
 			expect(
-				tooltips.useTooltip.args[0][0].props.children[4],
-				'useTooltip call 1'
-			).to.contain('499/444/408:');
+				codeRows[0].props.children[2],
+				'useTooltip row 1, response code row 1, value'
+			).to.be.equal(items[0][1].responses.codes['403']);
 			expect(
-				tooltips.useTooltip.args[0][0].props.children[5],
-				'useTooltip call 1'
-			).to.be.equal(2);
-			expect(tooltips.useTooltip.args[0][1], 'useTooltip call 1').to.be.equal('hint');
+				codeRows[1].props.children[0],
+				'useTooltip row 1, response code row 2, key'
+			).to.be.equal('404');
 			expect(
-				tooltips.useTooltip.args[1][0].props.children[0],
-				'useTooltip call 2'
-			).to.contain('4xx:');
+				codeRows[1].props.children[2],
+				'useTooltip row 1, response code row 2, value'
+			).to.be.equal(items[0][1].responses.codes['404']);
 			expect(
-				tooltips.useTooltip.args[1][0].props.children[1],
-				'useTooltip call 2'
-			).to.be.equal(50);
+				tooltips.useTooltip.args[0][0].props.children[1].props.children[0],
+				'useTooltip row 1, 499/444/408 row'
+			).to.contain('499/444/408');
 			expect(
-				tooltips.useTooltip.args[1][0].props.children[4],
-				'useTooltip call 2'
-			).to.contain('499/444/408:');
+				tooltips.useTooltip.args[0][0].props.children[1].props.children[1],
+				'useTooltip row 1, 499/444/408 row'
+			).to.be.equal(items[0][1].discarded);
+			expect(tooltips.useTooltip.args[0][1], 'useTooltip row 1, mode').to.be.equal('hint');
 			expect(
-				tooltips.useTooltip.args[1][0].props.children[5],
-				'useTooltip call 2'
-			).to.be.equal(3);
-			expect(tooltips.useTooltip.args[1][1], 'useTooltip call 2').to.be.equal('hint');
+				tooltips.useTooltip.args[1][0].props.children,
+				'useTooltip row 2, content length'
+			).to.have.lengthOf(2);
 			expect(
-				tooltips.useTooltip.args[2][0].props.children[0],
-				'useTooltip call 3'
-			).to.contain('4xx:');
+				tooltips.useTooltip.args[1][0].props.children[0].props.children[0],
+				'useTooltip row 2, 4xx row'
+			).to.contain('4xx');
 			expect(
-				tooltips.useTooltip.args[2][0].props.children[1],
-				'useTooltip call 3'
-			).to.be.equal(0);
+				tooltips.useTooltip.args[1][0].props.children[0].props.children[1],
+				'useTooltip row 2, 4xx row'
+			).to.be.equal(items[1][1].responses['4xx']);
 			expect(
-				tooltips.useTooltip.args[2][0].props.children[4],
-				'useTooltip call 3'
-			).to.contain('499/444/408:');
+				tooltips.useTooltip.args[1][0].props.children[1].props.children[0],
+				'useTooltip row 2, 499/444/408 row'
+			).to.contain('499/444/408');
 			expect(
-				tooltips.useTooltip.args[2][0].props.children[5],
-				'useTooltip call 3'
-			).to.be.equal(4);
-			expect(tooltips.useTooltip.args[2][1], 'useTooltip call 3').to.be.equal('hint');
+				tooltips.useTooltip.args[1][0].props.children[1].props.children[1],
+				'useTooltip row 2, 499/444/408 row'
+			).to.be.equal(items[1][1].discarded);
+			expect(tooltips.useTooltip.args[1][1], 'useTooltip row 2, mode').to.be.equal('hint');
+			expect(
+				tooltips.useTooltip.args[2][0].props.children,
+				'useTooltip row 3, content length'
+			).to.have.lengthOf(2);
+			expect(
+				tooltips.useTooltip.args[2][0].props.children[0].props.children[0],
+				'useTooltip row 3, 4xx row'
+			).to.contain('4xx');
+			expect(
+				tooltips.useTooltip.args[2][0].props.children[0].props.children[1],
+				'useTooltip row 3, 4xx row'
+			).to.be.equal(items[2][1].responses['4xx']);
+			expect(
+				tooltips.useTooltip.args[2][0].props.children[1].props.children[0],
+				'useTooltip row 3, 499/444/408 row'
+			).to.contain('499/444/408');
+			expect(
+				tooltips.useTooltip.args[2][0].props.children[1].props.children[1],
+				'useTooltip row 3, 499/444/408 row'
+			).to.be.equal(items[2][1].discarded);
+			expect(tooltips.useTooltip.args[2][1], 'useTooltip row 3, mode').to.be.equal('hint');
 
 			expect(utils.formatReadableBytes.callCount, 'useTooltip called').to.be.equal(12);
 			expect(utils.formatReadableBytes.args[0][0], 'useTooltip call 1 arg').to.be.equal(1);
@@ -436,6 +516,8 @@ describe('<ServerZones />', () => {
 
 			utils.formatReadableBytes.restore();
 			tooltips.useTooltip.restore();
+			utils.getHTTPCodesArray.restore();
+			tableUtils.responsesTextWithTooltip.restore();
 			wrapper.unmount();
 		});
 	});

--- a/src/components/pages/serverzones/locationzones.jsx
+++ b/src/components/pages/serverzones/locationzones.jsx
@@ -7,11 +7,15 @@
  */
 
 import React from 'react';
-import utils from '../../../utils';
-import SortableTable from '../../table/sortabletable.jsx';
-import TableSortControl from '../../table/tablesortcontrol.jsx';
-import tooltips from '../../../tooltips/index.jsx';
-import styles from '../../table/style.css';
+
+import utils from '#/utils.js';
+import tooltips from '#/tooltips/index.jsx';
+import {
+	SortableTable,
+	TableSortControl,
+	tableUtils,
+	styles,
+} from '#/components/table';
 
 export default class Locations extends SortableTable {
 	get SORTING_SETTINGS_KEY() {
@@ -70,19 +74,34 @@ export default class Locations extends SortableTable {
 									status = styles.alert;
 								}
 
+								const { codes } = location.responses;
+								const codes4xx = utils.getHTTPCodesArray(codes, '4');
+
 								return (<tr>
 									<td className={ status } />
 									<td className={ `${ styles['left-align'] } ${ styles.bold } ${ styles.bdr }` }>{ name }</td>
 									<td>{ location.requests }</td>
 									<td className={ styles.bdr }>{ location.zone_req_s }</td>
-									<td>{ location.responses['1xx'] }</td>
-									<td>{ location.responses['2xx'] }</td>
-									<td>{ location.responses['3xx'] }</td>
+									<td>{ tableUtils.responsesTextWithTooltip(location.responses['1xx'], codes, '1') }</td>
+									<td>{ tableUtils.responsesTextWithTooltip(location.responses['2xx'], codes, '2') }</td>
+									<td>{ tableUtils.responsesTextWithTooltip(location.responses['3xx'], codes, '3') }</td>
 									<td className={ `${ styles.flash }${ location['4xxChanged'] ? (' ' + styles['red-flash']) : '' }` }>
 										<span
 											className={ styles.hinted }
 											{ ...tooltips.useTooltip(
-												<div>4xx: { location.responses['4xx'] } <br /> 499/444/408: { location.discarded }</div>,
+												<div>
+													{
+														codes4xx.length > 0
+															? codes4xx.map(({ code, value }) => (
+																<div key={ code }>{ code }: { value }</div>
+															))
+															: (
+																<div>4xx: { location.responses['4xx'] }</div>
+															)
+													}
+
+													<div key="discarded">499/444/408: { location.discarded }</div>
+												</div>,
 												'hint'
 											) }
 										>
@@ -90,7 +109,7 @@ export default class Locations extends SortableTable {
 										</span>
 									</td>
 									<td className={ `${ styles.flash }${ location['5xxChanged'] ? (' ' + styles['red-flash']) : '' }` }>
-										{ location.responses['5xx'] }
+										{ tableUtils.responsesTextWithTooltip(location.responses['5xx'], codes, '5') }
 									</td>
 									<td className={ styles.bdr }>{ location.responses.total }</td>
 									<td className={ styles.px60 }>{ utils.formatReadableBytes(location.sent_s) }</td>

--- a/src/components/pages/serverzones/serverzones.jsx
+++ b/src/components/pages/serverzones/serverzones.jsx
@@ -7,11 +7,15 @@
  */
 
 import React from 'react';
-import utils from '../../../utils';
-import SortableTable from '../../table/sortabletable.jsx';
-import TableSortControl from '../../table/tablesortcontrol.jsx';
-import tooltips from '../../../tooltips/index.jsx';
-import styles from '../../table/style.css';
+
+import utils from '#/utils.js';
+import tooltips from '#/tooltips/index.jsx';
+import {
+	SortableTable,
+	TableSortControl,
+	tableUtils,
+	styles,
+} from '#/components/table';
 
 export default class StreamZones extends SortableTable {
 	get SORTING_SETTINGS_KEY() {
@@ -75,20 +79,35 @@ export default class StreamZones extends SortableTable {
 									status = styles.alert;
 								}
 
+								const { codes } = zone.responses;
+								const codes4xx = utils.getHTTPCodesArray(codes, '4');
+
 								return (<tr>
 									<td className={ status } />
 									<td className={ `${ styles['left-align'] } ${ styles.bold } ${ styles.bdr }` }>{ name }</td>
 									<td>{ zone.processing }</td>
 									<td>{ zone.requests }</td>
 									<td className={ styles.bdr }>{ zone.zone_req_s }</td>
-									<td>{ zone.responses['1xx'] }</td>
-									<td>{ zone.responses['2xx'] }</td>
-									<td>{ zone.responses['3xx'] }</td>
+									<td>{ tableUtils.responsesTextWithTooltip(zone.responses['1xx'], codes, '1') }</td>
+									<td>{ tableUtils.responsesTextWithTooltip(zone.responses['2xx'], codes, '2') }</td>
+									<td>{ tableUtils.responsesTextWithTooltip(zone.responses['3xx'], codes, '3') }</td>
 									<td className={`${ styles.flash }${zone['4xxChanged'] ? (' ' + styles['red-flash']) : ''}`}>
 										<span
 											className={ styles.hinted }
 											{ ...tooltips.useTooltip(
-												<div>4xx: { zone.responses['4xx'] } <br /> 499/444/408: { zone.discarded }</div>,
+												<div>
+													{
+														codes4xx.length > 0
+															? codes4xx.map(({ code, value }) => (
+																<div key={ code }>{ code }: { value }</div>
+															))
+															: (
+																<div>4xx: { zone.responses['4xx'] }</div>
+															)
+													}
+
+													<div key="discarded">499/444/408: { zone.discarded }</div>
+												</div>,
 												'hint'
 											) }
 										>
@@ -96,7 +115,7 @@ export default class StreamZones extends SortableTable {
 										</span>
 									</td>
 									<td className={`${ styles.flash }${zone['5xxChanged'] ? (' ' + styles['red-flash']) : ''}`}>
-										{ zone.responses['5xx'] }
+										{ tableUtils.responsesTextWithTooltip(zone.responses['5xx'], codes, '5') }
 									</td>
 									<td className={ styles.bdr }>{ zone.responses.total }</td>
 									<td className={ styles.px60 }>{ utils.formatReadableBytes(zone.sent_s) }</td>

--- a/src/components/pages/streamupstreams/streamupstream.jsx
+++ b/src/components/pages/streamupstreams/streamupstream.jsx
@@ -5,13 +5,13 @@
  *
  */
 import React from 'react';
+
 import TableSortControl from '../../table/tablesortcontrol.jsx';
 import UpstreamsList from '../../upstreams/upstreamslist.jsx';
-import utils from '../../../utils.js';
-import tooltips from '../../../tooltips/index.jsx';
+import utils from '#/utils.js';
+import tooltips from '#/tooltips/index.jsx';
 import PeerTooltip from '../../upstreams/PeerTooltip.jsx';
 import ConnectionsTooltip from '../../upstreams/ConnectionsTooltip.jsx';
-
 import styles from '../../table/style.css';
 
 export default class StreamUpstream extends UpstreamsList {

--- a/src/components/pages/streamzones.jsx
+++ b/src/components/pages/streamzones.jsx
@@ -6,11 +6,12 @@
  */
 
 import React from 'react';
-import api from '../../api';
+
+import api from '#/api';
 import DataBinder from '../databinder/databinder.jsx';
-import calculateStreamLimitConn from '../../calculators/streamlimitconn.js';
+import calculateStreamLimitConn from '#/calculators/streamlimitconn.js';
 import LimitConn from './serverzones/limitconn.jsx';
-import utils from '../../utils';
+import utils from '#/utils.js';
 import styles from '../table/style.css';
 
 export class StreamZones extends React.Component {

--- a/src/components/pages/upstreams/__test__/upstream.test.jsx
+++ b/src/components/pages/upstreams/__test__/upstream.test.jsx
@@ -13,6 +13,7 @@ import tooltips from '../../../../tooltips/index.jsx';
 import utils from '../../../../utils.js';
 import Upstream from '../upstream.jsx';
 import styles from '../../../table/style.css';
+import { tableUtils } from '#/components/table';
 
 describe('<Upstream />', () => {
 	const props = {
@@ -81,7 +82,8 @@ describe('<Upstream />', () => {
 
 		expect(instance.setState.calledOnce, 'this.setState called').to.be.true;
 		expect(instance.setState.args[0][0], 'this.setState args').to.be.deep.equal({
-			columnsExpanded: true
+			columnsExpanded: true,
+			hoveredColumns: false,
 		});
 		expect(appsettings.setSetting.calledOnce, 'appsettings.setSetting called').to.be.true;
 		expect(appsettings.setSetting.args[0][0], 'appsettings.setSetting arg 1').to.be.equal(
@@ -133,7 +135,16 @@ describe('<Upstream />', () => {
 				'2xx': 110,
 				'3xx': 1,
 				'4xx': 10,
-				'5xx': 2
+				'5xx': 2,
+				codes: {
+					200: 100,
+					201: 10,
+					301: 1,
+					400: 2,
+					403: 2,
+					404: 6,
+					500: 2,
+				},
 			},
 			'4xxChanged': true,
 			'5xxChanged': false,
@@ -162,6 +173,11 @@ describe('<Upstream />', () => {
 				'1xx': 1,
 				'2xx': 210,
 				'3xx': 2,
+				codes: {
+					200: 200,
+					201: 10,
+					301: 2,
+				},
 			},
 			'4xxChanged': false,
 			'5xxChanged': true,
@@ -175,6 +191,12 @@ describe('<Upstream />', () => {
 				'1xx': 2,
 				'2xx': 310,
 				'3xx': 3,
+				codes: {
+					200: 200,
+					201: 110,
+					301: 2,
+					302: 1,
+				},
 			},
 			health_checks: {},
 			health_status: true
@@ -204,9 +226,13 @@ describe('<Upstream />', () => {
 		stub(utils, 'formatUptime').callsFake(() => 'time_formatted');
 		stub(utils, 'formatReadableBytes').callsFake(() => 'readable_bytes_formatted');
 		stub(utils, 'formatMs').callsFake(() => 'ms_formatted');
+		stub(tableUtils, 'responsesTextWithTooltip').callsFake((value) => value);
 		stub(instance, 'editSelectedUpstream').callsFake(() => 'edit_selected_upstream_result');
 		stub(instance, 'hoverColumns').callsFake(() => 'hover_columns_result');
 
+		/**
+		 * Empty list
+		 */
 		let table = shallow(
 			instance.renderPeers([])
 		);
@@ -283,6 +309,9 @@ describe('<Upstream />', () => {
 		expect(instance.renderEmptyList.calledOnce, 'this.renderEmptyList called once').to.be.true;
 		expect(instance.getCheckbox.notCalled, 'this.getCheckbox not called').to.be.true;
 
+		/**
+		 * Non empty list
+		 */
 		tooltips.useTooltip.resetHistory();
 		instance.renderEmptyList.resetHistory();
 		table = shallow(
@@ -469,6 +498,80 @@ describe('<Upstream />', () => {
 		).to.be.deep.equal(peers[2]);
 		expect(tooltips.useTooltip.args[9][1], 'useTooltip, call 10, arg 2').to.be.equal('hint');
 
+		expect(tableUtils.responsesTextWithTooltip.callCount, 'responsesTextWithTooltip called 6 times').to.be.equal(6);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[0][0],
+			'[cols collapsed] responsesTextWithTooltip peer 1, 4xx, arg 1'
+		).to.be.equal(peers[0].responses['4xx']);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[0][1],
+			'[cols collapsed] responsesTextWithTooltip peer 1, 4xx, arg 2'
+		).to.be.equal(peers[0].responses.codes);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[0][2],
+			'[cols collapsed] responsesTextWithTooltip peer 1, 4xx, arg 3'
+		).to.be.equal('4');
+		expect(
+			tableUtils.responsesTextWithTooltip.args[1][0],
+			'[cols collapsed] responsesTextWithTooltip peer 1, 5xx, arg 1'
+		).to.be.equal(peers[0].responses['5xx']);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[1][1],
+			'[cols collapsed] responsesTextWithTooltip peer 1, 5xx, arg 2'
+		).to.be.equal(peers[0].responses.codes);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[1][2],
+			'[cols collapsed] responsesTextWithTooltip peer 1, 5xx, arg 3'
+		).to.be.equal('5');
+		expect(
+			tableUtils.responsesTextWithTooltip.args[2][0],
+			'[cols collapsed] responsesTextWithTooltip peer 2, 4xx, arg 1'
+		).to.be.equal(peers[1].responses['4xx']);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[2][1],
+			'[cols collapsed] responsesTextWithTooltip peer 2, 4xx, arg 2'
+		).to.be.equal(peers[1].responses.codes);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[2][2],
+			'[cols collapsed] responsesTextWithTooltip peer 2, 4xx, arg 3'
+		).to.be.equal('4');
+		expect(
+			tableUtils.responsesTextWithTooltip.args[3][0],
+			'[cols collapsed] responsesTextWithTooltip peer 2, 5xx, arg 1'
+		).to.be.equal(peers[1].responses['5xx']);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[3][1],
+			'[cols collapsed] responsesTextWithTooltip peer 2, 5xx, arg 2'
+		).to.be.equal(peers[1].responses.codes);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[3][2],
+			'[cols collapsed] responsesTextWithTooltip peer 2, 5xx, arg 3'
+		).to.be.equal('5');
+		expect(
+			tableUtils.responsesTextWithTooltip.args[4][0],
+			'[cols collapsed] responsesTextWithTooltip peer 3, 4xx, arg 1'
+		).to.be.equal(peers[2].responses['4xx']);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[4][1],
+			'[cols collapsed] responsesTextWithTooltip peer 3, 4xx, arg 2'
+		).to.be.equal(peers[2].responses.codes);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[4][2],
+			'[cols collapsed] responsesTextWithTooltip peer 3, 4xx, arg 3'
+		).to.be.equal('4');
+		expect(
+			tableUtils.responsesTextWithTooltip.args[5][0],
+			'[cols collapsed] responsesTextWithTooltip peer 3, 5xx, arg 1'
+		).to.be.equal(peers[2].responses['5xx']);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[5][1],
+			'[cols collapsed] responsesTextWithTooltip peer 3, 5xx, arg 2'
+		).to.be.equal(peers[2].responses.codes);
+		expect(
+			tableUtils.responsesTextWithTooltip.args[5][2],
+			'[cols collapsed] responsesTextWithTooltip peer 3, 5xx, arg 3'
+		).to.be.equal('5');
+
 		expect(utils.formatUptime.calledThrice, 'formatUptime called thrice').to.be.true;
 		expect(utils.formatUptime.args[0][0], 'formatUptime call 1, arg 1').to.be.equal(1000);
 		expect(utils.formatUptime.args[0][1], 'formatUptime call 1, arg 2').to.be.true;
@@ -501,6 +604,10 @@ describe('<Upstream />', () => {
 
 		expect(table.find(`.${ styles['edit-peer'] }`), '[editMode = false] edit-peer').to.have.lengthOf(0);
 
+		/**
+		 * Non empty list in edit mode + expanded columns
+		 */
+		tableUtils.responsesTextWithTooltip.resetHistory();
 		wrapper.setState({
 			hoveredColumns: true,
 			editMode: true,
@@ -525,6 +632,72 @@ describe('<Upstream />', () => {
 			table.find('thead').childAt(1).children(),
 			'[columnsExpanded = true] head row 2, children length'
 		).to.have.lengthOf(25);
+
+		expect(tableUtils.responsesTextWithTooltip.callCount, 'responsesTextWithTooltip called 15 times').to.be.equal(15);
+		peers.forEach((peer, i) => {
+			const j = i*5;
+
+			expect(
+				tableUtils.responsesTextWithTooltip.args[0+j][0],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 1xx, arg 1`
+			).to.be.equal(peers[i].responses['1xx']);
+			expect(
+				tableUtils.responsesTextWithTooltip.args[0+j][1],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 1xx, arg 2`
+			).to.be.equal(peers[i].responses.codes);
+			expect(
+				tableUtils.responsesTextWithTooltip.args[0+j][2],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 1xx, arg 3`
+			).to.be.equal('1');
+			expect(
+				tableUtils.responsesTextWithTooltip.args[1+j][0],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 2xx, arg 1`
+			).to.be.equal(peers[i].responses['2xx']);
+			expect(
+				tableUtils.responsesTextWithTooltip.args[1+j][1],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 2xx, arg 2`
+			).to.be.equal(peers[i].responses.codes);
+			expect(
+				tableUtils.responsesTextWithTooltip.args[1+j][2],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 2xx, arg 3`
+			).to.be.equal('2');
+			expect(
+				tableUtils.responsesTextWithTooltip.args[2+j][0],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 3xx, arg 1`
+			).to.be.equal(peers[i].responses['3xx']);
+			expect(
+				tableUtils.responsesTextWithTooltip.args[2+j][1],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 3xx, arg 2`
+			).to.be.equal(peers[i].responses.codes);
+			expect(
+				tableUtils.responsesTextWithTooltip.args[2+j][2],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 3xx, arg 3`
+			).to.be.equal('3');
+			expect(
+				tableUtils.responsesTextWithTooltip.args[3+j][0],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 4xx, arg 1`
+			).to.be.equal(peers[i].responses['4xx']);
+			expect(
+				tableUtils.responsesTextWithTooltip.args[3+j][1],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 4xx, arg 2`
+			).to.be.equal(peers[i].responses.codes);
+			expect(
+				tableUtils.responsesTextWithTooltip.args[3+j][2],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 4xx, arg 3`
+			).to.be.equal('4');
+			expect(
+				tableUtils.responsesTextWithTooltip.args[4+j][0],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 5xx, arg 1`
+			).to.be.equal(peers[i].responses['5xx']);
+			expect(
+				tableUtils.responsesTextWithTooltip.args[4+j][1],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 5xx, arg 2`
+			).to.be.equal(peers[i].responses.codes);
+			expect(
+				tableUtils.responsesTextWithTooltip.args[4+j][2],
+				`[cols expanded] responsesTextWithTooltip row ${i}, 5xx, arg 3`
+			).to.be.equal('5');
+		});
 
 		const editPeer = table.find(`.${ styles['edit-peer'] }`);
 
@@ -675,6 +848,7 @@ describe('<Upstream />', () => {
 		utils.formatUptime.restore();
 		utils.formatReadableBytes.restore();
 		utils.formatMs.restore();
+		tableUtils.responsesTextWithTooltip.restore();
 		instance.editSelectedUpstream.restore();
 		instance.hoverColumns.restore();
 	});

--- a/src/components/table/__test__/utils.test.jsx
+++ b/src/components/table/__test__/utils.test.jsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2017-present, Nginx, Inc.
+ * Copyright 2017-present, Igor Meleshchenko
+ * All rights reserved.
+ *
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { spy, stub } from 'sinon';
+
+import utils from '#/utils.js';
+import tooltips from '#/tooltips/index.jsx';
+import { responsesTextWithTooltip } from '../utils.jsx';
+
+describe('Table utils', () => {
+	describe('responsesTextWithTooltip()', () => {
+		const textResult = 'textResult';
+		const codes = {
+			'101': 10,
+			'102': 7,
+			'200': 320,
+		};
+		const codeGroup = '1';
+		const useTooltipResult = 'useTooltipResult';
+
+		before(() => {
+			stub(tooltips, 'useTooltip').callsFake(() => ({ useTooltipResult }));
+		});
+
+		afterEach(() => {
+			tooltips.useTooltip.resetHistory();
+		});
+
+		after(() => {
+			tooltips.useTooltip.restore();
+		});
+
+		it('Empty codes', () => {
+			expect(responsesTextWithTooltip(textResult, {}, codeGroup)).to.be.equal(textResult);
+			expect(tooltips.useTooltip.callCount, 'useTooltip was not called').to.be.equal(0);
+		});
+
+		it('With codes', () => {
+			const result = responsesTextWithTooltip(textResult, codes, codeGroup);
+
+			expect(result.props.children, 'result text').to.be.equal(textResult);
+			expect(result.props.useTooltipResult, 'tooltip props were extracted').to.be.equal(useTooltipResult);
+
+			expect(tooltips.useTooltip.calledOnce, 'useTooltip called once').to.be.true;
+			const tooltipContent = tooltips.useTooltip.args[0][0].props.children;
+			expect(tooltipContent, 'tooltip content length').to.have.lengthOf(2);
+			expect(tooltipContent[0].props.children[0], 'tooltip content row 1, key').to.be.equal('101');
+			expect(tooltipContent[0].props.children[2], 'tooltip content row 1, value').to.be.equal(10);
+			expect(tooltipContent[1].props.children[0], 'tooltip content row 1, key').to.be.equal('102');
+			expect(tooltipContent[1].props.children[2], 'tooltip content row 1, value').to.be.equal(7);
+		});
+	});
+});

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2017-present, Nginx, Inc.
+ * Copyright 2017-present, Ivan Poluyanov
+ * Copyright 2017-present, Igor Meleschenko
+ * All rights reserved.
+ *
+ */
+
+import SortableTable from './sortabletable.jsx';
+import TableSortControl from './tablesortcontrol.jsx';
+import styles from './style.css';
+import tableUtils from './utils.jsx';
+
+export {
+	SortableTable,
+	TableSortControl,
+	tableUtils,
+	styles,
+};

--- a/src/components/table/utils.jsx
+++ b/src/components/table/utils.jsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2022-present, Nginx, Inc.
+ * Copyright 2022-present, Igor Meleshchenko
+ * All rights reserved.
+ *
+ */
+
+import React from 'react';
+
+import utils from '#/utils.js';
+import tooltips from '#/tooltips/index.jsx';
+import styles from './style.css';
+
+export const responsesTextWithTooltip = (text, codes, codeGroup) => {
+  const codesArr = utils.getHTTPCodesArray(codes, codeGroup);
+
+  return codesArr.length > 0
+    ? (
+      <span
+        className={ styles.hinted }
+        { ...tooltips.useTooltip(
+          <div>
+            {
+              codesArr.map(({ code, value }) => (
+                <div key={ code }>{ code }: { value }</div>
+              ))
+            }
+          </div>
+        ) }
+      >{ text }</span>
+    )
+    : text;
+};
+
+export default {
+  responsesTextWithTooltip,
+};

--- a/src/components/upstreams/ConnectionsTooltip.jsx
+++ b/src/components/upstreams/ConnectionsTooltip.jsx
@@ -1,4 +1,3 @@
-
 /**
  * Copyright 2017-present, Nginx, Inc.
  * Copyright 2017-present, Ivan Poluyanov
@@ -7,8 +6,9 @@
  */
 
 import React from 'react';
+
 import styles from './tooltip.css';
-import utils from '../../utils.js';
+import utils from '#/utils.js';
 
 export default function ConnectionsTooltip({ peer }){
 	return (

--- a/src/components/upstreams/PeerTooltip.jsx
+++ b/src/components/upstreams/PeerTooltip.jsx
@@ -7,8 +7,9 @@
  */
 
 import React from 'react';
+
 import styles from './tooltip.css';
-import utils from '../../utils.js';
+import utils from '#/utils.js';
 
 export default function PeerTooltip({ peer }){
 	let state = null;

--- a/src/components/upstreams/index.js
+++ b/src/components/upstreams/index.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2017-present, Nginx, Inc.
+ * Copyright 2017-present, Ivan Poluyanov
+ * All rights reserved.
+ *
+ */
+
+import UpstreamsList from './upstreamslist.jsx';
+import PeerTooltip from './PeerTooltip.jsx';
+import ConnectionsTooltip from './ConnectionsTooltip.jsx';
+
+export {
+	UpstreamsList,
+	PeerTooltip,
+	ConnectionsTooltip,
+};

--- a/src/datastore/__test__/index.test.js
+++ b/src/datastore/__test__/index.test.js
@@ -205,6 +205,10 @@ describe('Datastore', () => {
 		expect(promiseAllCatchSpy.calledOnce, 'Promise.all catch called').to.be.true;
 		expect(promiseAllCatchSpy.args[0][0], 'Promise.all catch call arg').to.be.a('function');
 
+		startObserve();
+
+		expect(live, '[no force, live] live is still true').to.be.true;
+
 		OBSERVED.delete('api_1');
 
 		Promise.all.restore();

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 /**
  * Copyright 2017-present, Nginx, Inc.
  * Copyright 2017-present, Ivan Poluyanov
+ * Copyright 2022-present, Igor Meleshchenko
  * All rights reserved.
  *
  */
@@ -63,7 +64,7 @@ export const formatReadableBytes = (
 		measure = 2;
 	} else if (bytes > 1023 && bytes <= 1024000) {
 		measure = 1;
-	} else if (bytes <= 1023) {
+	} else {
 		measure = 0;
 	}
 
@@ -93,9 +94,27 @@ export const formatDate = (timestamp) => {
 	return `${ datetime.toISOString().slice(0, 10) } ${ time[0] } ${ time[1] }`;
 };
 
+export const getHTTPCodesArray = (codes, codeGroup) => {
+	const result = [];
+
+	if (codes && Object.keys(codes).length > 0) {
+		Object.keys(codes).sort().forEach(code => {
+			if (`${code}`.startsWith(codeGroup)) {
+				result.push({
+					code,
+					value: codes[code],
+				});
+			}
+		});
+	}
+
+	return result;
+};
+
 export default {
 	formatUptime,
 	formatReadableBytes,
 	formatMs,
 	formatDate,
+	getHTTPCodesArray,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,6 +150,7 @@ const config = {
     resolve: {
         alias: {
             'react': path.resolve(__dirname, 'src/preact-exports.js'),
+            '#': path.resolve(__dirname, 'src'),
         }
     },
     module: {


### PR DESCRIPTION
1. For HTTP Server zones, Location zones and Upstreams we now display detailed statistic for response codes. If there's a list of codes presented in the API related to the particular codes group (e.g. 1xx, 2xx, etc.) we are able to see it in a tooltip
<img width="1784" alt="image" src="https://user-images.githubusercontent.com/3491165/188597443-9cc1b086-c9d7-4660-9efd-01d48ec1d18a.png">

2. When expand Responses columns in HTTP Upstreams table new columns appear with a "faded out" styles, which should be added when you hover collapse control. This is fixed now.
